### PR TITLE
Update CircleCI configuration for pushing to container registries

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  architect: giantswarm/architect@4.34.1
+  architect: giantswarm/architect@4.35.5
 
 jobs:
   build-binary:
@@ -13,38 +13,38 @@ jobs:
         default: "master"
         type: string
     steps:
-      - run: 
+      - run:
           command: git clone https://github.com/coredns/coredns.git
           name: Cloning CoreDNS repository
 
-      - run: 
+      - run:
           command: cd coredns && git checkout << parameters.coredns_reference >>
           name: Checking out reference
 
       - checkout:
           path: plugin
 
-      - run: 
+      - run:
           command: ./plugin/patch-plugin.sh coredns plugin
           name: Patching CoreDNS plugin manifest
 
-      - run: 
+      - run:
           command: cd coredns && make
           name: Building CoreDNS binary
 
-      - run: 
+      - run:
           command: mv ./coredns/coredns ./coredns-binary
           name: Moving CoreDNS binary
-        
-      - run: 
+
+      - run:
           command: rm -rf ./coredns
           name: Removing CoreDNS repo
 
-      - run: 
+      - run:
           command: mv coredns-binary coredns
           name: Restoring CoreDNS binary
 
-      - run: 
+      - run:
           command: ./coredns -version
           name: Printing CoreDNS version
 
@@ -52,7 +52,7 @@ jobs:
           root: .
           paths:
             - coredns
-  
+
   create-cluster:
     machine:
       image: ubuntu-2204:2022.10.2
@@ -97,7 +97,7 @@ jobs:
           name: Wait for all pods to be ready
           command: |
             ./kubectl rollout status -w -n kube-system deployment/coredns --timeout=5m
-  
+
   install-flamethrower:
     docker:
       - image: quay.io/giantswarm/helm-chart-testing:v3.3.1
@@ -107,8 +107,10 @@ jobs:
         default: "helm/flamethrower"
         type: string
     steps:
-      - run: 
-          command: helm install --repo https://raw.githubusercontent.com/giantswarm/giantswarm-playground-catalog/master/ flamethrower flamethrower
+      - run:
+          command: helm install --repo 
+            https://raw.githubusercontent.com/giantswarm/giantswarm-playground-catalog/master/
+            flamethrower flamethrower
           name: Installing Flamethrower
 
 
@@ -130,12 +132,9 @@ workflows:
             tags:
               only: /^v.*/
 
-      - architect/push-to-docker:
-          name: push-to-quay
-          context: "architect"
-          image: quay.io/giantswarm/coredns-warnlist-plugin
-          username_envar: "QUAY_USERNAME"
-          password_envar: "QUAY_PASSWORD"
+      - architect/push-to-registries:
+          context: architect
+          name: push-to-registries
           requires:
             - go-test
             - build-binary
@@ -143,19 +142,9 @@ workflows:
             # Trigger job also on git tag.
             tags:
               only: /^v.*/
-          post-steps:
-            # Persist the specified paths (workspace/echo-output) into the workspace for use in downstream job.
-            - persist_to_workspace:
-                # Must be an absolute path, or relative path from working_directory. This is a directory on the container which is
-                # taken to be the root directory of the workspace.
-                root: ./
-                # Must be relative path from root
-                paths:
-                  - .docker_image_name
-      
       - create-cluster:
           requires:
-            - push-to-quay
+            - push-to-registries
           filters:
             # Trigger job also on git tag.
             tags:


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/2979

Context: [announcement in `#news-dev` on Slack](https://gigantic.slack.com/archives/C04TGHDEF/p1701170353580999)

This PR was created through automation by Team Honeybadger, to make sure that the container images built for this repository are available in the right registries.

For that, the CircleCI configuration is modified to use the new [push-to-registries](https://github.com/giantswarm/architect-orb/blob/main/docs/job/push-to-registries.md) job instead of the old `push-to-docker`. This means that there is **only one job for all registry pushes**, and it simplifies the configuration by removing many parameters that are now set automatically or as defaults.

## Notes

- Since the PR is also changing the CircleCI job name to `push-to-registries`, the branch protection rules in this repository will likely require updating before the required checks can be green.
- Dev images are sent to ACR (gsoci.azurecr.io) and Quay currently. If you need dev images elsewhere, you can add the according configuration as described in the [documentation](https://github.com/giantswarm/architect-orb/blob/main/docs/job/push-to-registries.md) to the step configuration.

## To the responsible team

Please,

- [ ] Assign this PR to yourself
- [ ] Verify that the check `ci/circleci: push-to-registries` has been executed successfully.
- [ ] Double-check the job dependecies (`requires`)
- [ ] Double-check the job `filters`. Especially if this PR replaces several jobs with one, and the previous jobs had different filters, make sure that the filter includes all cases.
- [ ] Update the changelog if you think this deserves a mention
- [ ] Approve and merge this PR once it's ready. No need to wait for the author in this case.

Please get this done until **December 5**, so that we can move on with the next migration steps. Thank you!